### PR TITLE
Exclude jackson-databind from shaded jar

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -31,6 +31,12 @@
       <version>1.1.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+      <scope>test</scope>
+  </dependency>
   </dependencies>
   
   <build>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -33,6 +33,12 @@
       <artifactId>kite-morphlines-json</artifactId>
       <version>${kite-sdk.version}</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kitesdk</groupId>


### PR DESCRIPTION
Exclude `jackson-databind` from shaded .jar as it clashes with Spark's version in Cloudera Runtime 7.1.x. Looking at the dependency tree Spark includes `jackson-databind:2.6.5` whereas Envelope 0.7.2 is including `jackson-databind:2.3.1` as part of a `kitesdk` dependency. 